### PR TITLE
Prep for release v0.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        pg: [16, 15, 14, 13, 12, 11, 10]
+        pg: [17, 16, 15, 14, 13, 12, 11, 10]
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
@@ -19,4 +19,3 @@ jobs:
       - run: pg-start ${{ matrix.pg }}
       - uses: actions/checkout@v2
       - run: pg-build-test
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    tags: [v*]
+jobs:
+  release:
+    name: Release on PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    env:
+      PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+      PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+    - name: Bundle the Release
+      id: bundle
+      run: pgxn-bundle
+    - name: Release on PGXN
+      run: pgxn-release

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
 *.so
+*.dylib
+*.bc
 
 test/results
 test/regression.diffs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Adjust
+Copyright (c) 2022-2024 Adjust
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "name": "base62",
    "abstract": "Integers represented in base62",
-   "version": "0.0.1",
+   "version": "0.0.2",
    "maintainer" : [
       "adjustgmbh"
    ],
@@ -11,7 +11,7 @@
    "provides": { 
       "base36": {
          "file": "sql/base62.sql",
-         "version": "0.0.1",
+         "version": "0.0.2",
          "abstract": "Integers represented in base62"
       }
    },

--- a/base62--0.0.1--0.0.2.sql
+++ b/base62--0.0.1--0.0.2.sql
@@ -1,0 +1,1 @@
+-- No SQL changes.


### PR DESCRIPTION
Add test for Postgres 17 and increment the version to v0.0.2.

Add a GitHub workflow to auto-publish on PGXN on release. To use it, add your PGXN username and password to to your [GitHub Actions secrets]. Create these environment secrets:

*   PGXN_USERNAME
*   PGXN_PASSWORD

It should then publish when you push the tag `v0.0.2`.

While at it, ignore generated Bitcode (`.bc`) and darwin (`.dylb`) files.

[GitHub Actions secrets]: https://github.com/adjust/pg-base62/settings/secrets/actions